### PR TITLE
Fix Customize Comments - Segment content

### DIFF
--- a/minimal_reddit_3rd.user.styl
+++ b/minimal_reddit_3rd.user.styl
@@ -873,7 +873,7 @@ Image effets
 			}
 		}
 		if segmentCommentContent {
-			shreddit-comment > [slot="comment"] {
+			shreddit-comment [slot="comment"] {
 				background-color: var(--segment-comments-color) i;
   				padding: 10px 12px i;
 				margin: 0 i;


### PR DESCRIPTION
Shreddit broke today with Customize comments -> Segment content no longer working no matter the toggle's position. Seems they added a wrapper or something in-between. Removing > lets the style find the correct elements again.